### PR TITLE
feat(api): Individual Container CRUD operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ services:
   - docker
 
 script:
-  - npm run test
+  - npm run ci
   - npm run coverage

--- a/README.md
+++ b/README.md
@@ -32,9 +32,69 @@ npm install
 # Build the server
 npm run build
 
-# Star the server
+# Start the server
 npm run start
 ```
+
+## API Usage
+The dashboard currently offers a feature-limited API.
+
+### Currently supported apps
+The following apps will start without any issues:
+- Deluge
+- NZBGet
+- Plex (not configured OOB)
+- Radarr
+- Rutorrent
+- Sabnzbd
+- Sonarr
+- Traefik (not configured OOB)
+- Transmission
+
+Please note that **none** of these apps currently run as one would expect. The WebUIs will start but the paths aren't mapped to the main system yet. I advise you to **avoid** running Plex and Traefik at all, as they're still missing their configurations.
+
+### Containers
+The API currently allows you to perform basic CRUD operations on containers.
+
+All requests respond with at least the following details:
+```json
+{
+  "name": "radarr",
+  "image": "linuxserver/radarr:latest",
+  "internalPort": 7878,
+  "port": 7878,
+  "url": "http://localhost:7878",
+  "env": [
+    "GUID=501",
+    "PUID=20"
+  ],
+  "labels": {
+    "holo.app": "radarr",
+    "traefik.enabled": "true",
+    "traefik.frontend.rule": "Host:radarr.domain.tld",
+    "traefik.port": "7878"
+  },
+}
+```
+
+#### GET /api/containers
+Get a list of running containers.
+
+#### POST /api/containers?app=name
+_Replace `name` with one of Holo's supported app names._
+
+Creates a container for one of Holo's supported apps.
+
+#### GET /api/containers/name
+_Replace `name` with the actual app name_
+
+Get information on a currently running container.
+
+#### DELETE /api/containers/name
+_Replace `name` with the actual app name_
+
+Forcefully removes the container.
+
 
 ## You may also like...
 * [Cloudbox](https://github.com/Cloudbox/Cloudbox)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate": "prisma2 generate",
     "up": "prisma2 lift up",
     "test": "jest",
+    "ci": "jest --onlyChanged",
     "coverage": "codecov"
   },
   "dependencies": {

--- a/pages/api/containers/[id].ts
+++ b/pages/api/containers/[id].ts
@@ -1,0 +1,46 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { send } from 'micro';
+
+import Apps from '@dashboard/apps';
+
+function isApp(query: string): query is keyof typeof Apps {
+  return query in Apps;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req;
+
+  const { id } = req.query;
+  if (!id || typeof id !== 'string') {
+    return send(res, 400);
+  }
+
+  if (!isApp(id)) {
+    return send(res, 400);
+  }
+
+  const app = Apps[id];
+
+  if (method === 'GET') {
+    const container = await app.inspect();
+
+    if (!container) {
+      return send(res, 404);
+    }
+
+    return send(res, 200, container);
+  }
+
+  if (method === 'DELETE') {
+    const { force = 'true', deleteAppdata } = req.query;
+
+    try {
+      await app.remove(Boolean(force), Boolean(deleteAppdata));
+      return send(res, 200);
+    } catch {
+      return send(res, 404);
+    }
+  }
+
+  return send(res, 404);
+}


### PR DESCRIPTION
This PR adds two basic container CRUD operations:
- Inspecting a container with a GET request to /api/containers/id
- Removing a container with a DELETE request to /api/containers/id

Under the hood I also changed the behind the scenes API requests so it now delivers consistent results by calling the same methods.

Oh! And there is more documentation in the Readme regarding the current state of the API.